### PR TITLE
Add skeleton Go rewrite

### DIFF
--- a/golang/Dockerfile
+++ b/golang/Dockerfile
@@ -1,0 +1,8 @@
+FROM golang:1.20 AS builder
+WORKDIR /src
+COPY . .
+RUN go build -o /bin/ai-gateway ./cmd/gateway
+
+FROM gcr.io/distroless/base-debian11
+COPY --from=builder /bin/ai-gateway /bin/ai-gateway
+ENTRYPOINT ["/bin/ai-gateway"]

--- a/golang/README.md
+++ b/golang/README.md
@@ -1,0 +1,9 @@
+# AI Gateway Go Implementation
+
+This directory contains an experimental Go rewrite of the Rust-based AI Gateway.
+It mirrors the original functionality with Gin-based HTTP endpoints, dynamic
+model routing, guardrails, cost tracking, observability via OpenTelemetry, a
+real-time terminal UI, and MCP tool integration.
+
+The code is incomplete and serves as a starting point for a full-featured Go
+version of the gateway.

--- a/golang/cmd/gateway/main.go
+++ b/golang/cmd/gateway/main.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"context"
+	"log"
+
+	"github.com/ai-gateway/ai-gateway-go/internal/config"
+	"github.com/ai-gateway/ai-gateway-go/internal/server"
+)
+
+func main() {
+	cfg, err := config.Load()
+	if err != nil {
+		log.Fatalf("failed to load config: %v", err)
+	}
+
+	srv := server.New(cfg)
+	if err := srv.Start(context.Background()); err != nil {
+		log.Fatalf("server error: %v", err)
+	}
+}

--- a/golang/config/config.sample.yaml
+++ b/golang/config/config.sample.yaml
@@ -1,0 +1,4 @@
+address: ":8080"
+models_path: "models.yaml"
+telemetry_url: "localhost:4318"
+clickhouse_url: "http://localhost:8123"

--- a/golang/go.mod
+++ b/golang/go.mod
@@ -1,0 +1,10 @@
+module github.com/ai-gateway/ai-gateway-go
+
+go 1.20
+
+require (
+    github.com/gin-gonic/gin v1.9.1
+    github.com/spf13/viper v1.15.0
+    go.opentelemetry.io/otel v1.17.0
+    go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.17.0
+)

--- a/golang/internal/config/config.go
+++ b/golang/internal/config/config.go
@@ -1,0 +1,29 @@
+package config
+
+import (
+	"github.com/spf13/viper"
+)
+
+type Config struct {
+	Address       string `mapstructure:"address"`
+	ModelsPath    string `mapstructure:"models_path"`
+	TelemetryURL  string `mapstructure:"telemetry_url"`
+	ClickHouseURL string `mapstructure:"clickhouse_url"`
+}
+
+func Load() (*Config, error) {
+	v := viper.New()
+	v.SetConfigName("config")
+	v.SetConfigType("yaml")
+	v.AddConfigPath(".")
+	v.AddConfigPath("./config")
+	v.AutomaticEnv()
+	if err := v.ReadInConfig(); err != nil {
+		return nil, err
+	}
+	var c Config
+	if err := v.Unmarshal(&c); err != nil {
+		return nil, err
+	}
+	return &c, nil
+}

--- a/golang/internal/guardrails/guardrails.go
+++ b/golang/internal/guardrails/guardrails.go
@@ -1,0 +1,26 @@
+package guardrails
+
+import (
+	"errors"
+	"strings"
+)
+
+// Guardrails performs simple input validation.
+type Guardrails struct {
+	banned []string
+}
+
+func New() *Guardrails {
+	return &Guardrails{banned: []string{"banned"}}
+}
+
+// CheckInput returns an error if input contains banned words.
+func (g *Guardrails) CheckInput(input string) error {
+	lower := strings.ToLower(input)
+	for _, w := range g.banned {
+		if strings.Contains(lower, w) {
+			return errors.New("input violates guardrails")
+		}
+	}
+	return nil
+}

--- a/golang/internal/mcp/client.go
+++ b/golang/internal/mcp/client.go
@@ -1,0 +1,11 @@
+package mcp
+
+// Client placeholder for external tool execution via MCP.
+type Client struct{}
+
+func New() *Client { return &Client{} }
+
+func (c *Client) Execute(tool string, input any) (any, error) {
+	// TODO: implement MCP protocol
+	return nil, nil
+}

--- a/golang/internal/metrics/metrics.go
+++ b/golang/internal/metrics/metrics.go
@@ -1,0 +1,22 @@
+package metrics
+
+import "sync"
+
+type Usage struct {
+	mu     sync.Mutex
+	tokens int
+	cost   float64
+}
+
+func (u *Usage) AddTokens(n int, price float64) {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	u.tokens += n
+	u.cost += float64(n) * price
+}
+
+func (u *Usage) Cost() float64 {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	return u.cost
+}

--- a/golang/internal/observability/otel.go
+++ b/golang/internal/observability/otel.go
@@ -1,0 +1,22 @@
+package observability
+
+import (
+	"context"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
+	"go.opentelemetry.io/otel/sdk/resource"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+)
+
+func Setup(ctx context.Context, url string) (*sdktrace.TracerProvider, error) {
+	exp, err := otlptracehttp.New(ctx, otlptracehttp.WithEndpoint(url))
+	if err != nil {
+		return nil, err
+	}
+	tp := sdktrace.NewTracerProvider(
+		sdktrace.WithBatcher(exp),
+		sdktrace.WithResource(resource.Empty()),
+	)
+	otel.SetTracerProvider(tp)
+	return tp, nil
+}

--- a/golang/internal/provider/echo/echo.go
+++ b/golang/internal/provider/echo/echo.go
@@ -1,0 +1,25 @@
+package echo
+
+import (
+	"context"
+
+	"github.com/ai-gateway/ai-gateway-go/internal/provider"
+)
+
+// Provider responds by echoing the last user message.
+type Provider struct{}
+
+func New() *Provider { return &Provider{} }
+
+func (p *Provider) Chat(ctx context.Context, req *provider.ChatRequest) (<-chan provider.Message, error) {
+	ch := make(chan provider.Message, 1)
+	go func() {
+		defer close(ch)
+		if len(req.Messages) == 0 {
+			return
+		}
+		last := req.Messages[len(req.Messages)-1]
+		ch <- provider.Message{Role: "assistant", Content: "Echo: " + last.Content}
+	}()
+	return ch, nil
+}

--- a/golang/internal/provider/provider.go
+++ b/golang/internal/provider/provider.go
@@ -1,0 +1,21 @@
+package provider
+
+import "context"
+
+// Message represents a chat message.
+type Message struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+// ChatRequest mirrors the OpenAI chat completion request.
+type ChatRequest struct {
+	Model    string    `json:"model"`
+	Messages []Message `json:"messages"`
+	Stream   bool      `json:"stream,omitempty"`
+}
+
+// Provider handles LLM operations.
+type Provider interface {
+	Chat(ctx context.Context, req *ChatRequest) (<-chan Message, error)
+}

--- a/golang/internal/routing/router.go
+++ b/golang/internal/routing/router.go
@@ -1,0 +1,50 @@
+package routing
+
+import "github.com/ai-gateway/ai-gateway-go/internal/provider"
+
+// Model describes a model and its provider weight.
+type Model struct {
+	Name   string
+	Weight int
+}
+
+// Router maps models to providers.
+type Router struct {
+	models    []Model
+	providers map[string]provider.Provider
+	defaultP  provider.Provider
+}
+
+func New() *Router {
+	return &Router{
+		models:    []Model{{Name: "echo", Weight: 1}},
+		providers: make(map[string]provider.Provider),
+	}
+}
+
+// Register associates a model with a provider implementation.
+func (r *Router) Register(model string, p provider.Provider) {
+	r.providers[model] = p
+	if r.defaultP == nil {
+		r.defaultP = p
+	}
+}
+
+// ProviderFor returns the provider for a model or the default provider.
+func (r *Router) ProviderFor(model string) provider.Provider {
+	if p, ok := r.providers[model]; ok {
+		return p
+	}
+	return r.defaultP
+}
+
+func (r *Router) Select() Model {
+	if len(r.models) == 0 {
+		return Model{}
+	}
+	return r.models[0]
+}
+
+func (r *Router) Models() []Model {
+	return r.models
+}

--- a/golang/internal/routing/router_test.go
+++ b/golang/internal/routing/router_test.go
@@ -1,0 +1,16 @@
+package routing
+
+import (
+	"testing"
+
+	"github.com/ai-gateway/ai-gateway-go/internal/provider/echo"
+)
+
+func TestRouterProvider(t *testing.T) {
+	r := New()
+	p := echo.New()
+	r.Register("echo", p)
+	if r.ProviderFor("echo") == nil {
+		t.Fatalf("expected provider")
+	}
+}

--- a/golang/internal/server/server.go
+++ b/golang/internal/server/server.go
@@ -1,0 +1,100 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/ai-gateway/ai-gateway-go/internal/config"
+	"github.com/ai-gateway/ai-gateway-go/internal/guardrails"
+	"github.com/ai-gateway/ai-gateway-go/internal/provider"
+	"github.com/ai-gateway/ai-gateway-go/internal/provider/echo"
+	"github.com/ai-gateway/ai-gateway-go/internal/routing"
+)
+
+type Server struct {
+	cfg    *config.Config
+	engine *gin.Engine
+	router *routing.Router
+	guards *guardrails.Guardrails
+}
+
+func New(cfg *config.Config) *Server {
+	r := gin.Default()
+	rt := routing.New()
+	rt.Register("echo", echo.New())
+	srv := &Server{cfg: cfg, engine: r, router: rt, guards: guardrails.New()}
+	srv.registerRoutes()
+	return srv
+}
+
+func (s *Server) registerRoutes() {
+	api := s.engine.Group("/v1")
+	api.POST("/chat/completions", s.chatCompletion)
+	api.POST("/embeddings", s.embeddings)
+	api.GET("/models", s.listModels)
+}
+
+func (s *Server) Start(ctx context.Context) error {
+	srv := &http.Server{
+		Addr:    s.cfg.Address,
+		Handler: s.engine,
+	}
+	go func() {
+		<-ctx.Done()
+		_ = srv.Shutdown(context.Background())
+	}()
+	return srv.ListenAndServe()
+}
+
+func (s *Server) chatCompletion(c *gin.Context) {
+	var req provider.ChatRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request"})
+		return
+	}
+	if len(req.Messages) > 0 {
+		last := req.Messages[len(req.Messages)-1]
+		if err := s.guards.CheckInput(last.Content); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+	}
+	prov := s.router.ProviderFor(req.Model)
+	stream, err := prov.Chat(c.Request.Context(), &req)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	if req.Stream {
+		c.Writer.Header().Set("Content-Type", "text/event-stream")
+		c.Writer.Header().Set("Cache-Control", "no-cache")
+		c.Writer.Flush()
+		enc := json.NewEncoder(c.Writer)
+		for msg := range stream {
+			if err := enc.Encode(msg); err != nil {
+				break
+			}
+			fmt.Fprint(c.Writer, "\n")
+			c.Writer.Flush()
+		}
+	} else {
+		var msgs []provider.Message
+		for m := range stream {
+			msgs = append(msgs, m)
+		}
+		c.JSON(http.StatusOK, gin.H{"choices": msgs})
+	}
+}
+
+func (s *Server) embeddings(c *gin.Context) {
+	c.JSON(200, gin.H{"message": "not implemented"})
+}
+
+func (s *Server) listModels(c *gin.Context) {
+	c.JSON(200, gin.H{"models": s.router.Models()})
+}

--- a/golang/internal/tui/tui.go
+++ b/golang/internal/tui/tui.go
@@ -1,0 +1,10 @@
+package tui
+
+// TUI is a placeholder for real-time terminal UI.
+type TUI struct{}
+
+func New() *TUI { return &TUI{} }
+
+func (t *TUI) Run() {
+	// TODO: implement terminal dashboard
+}


### PR DESCRIPTION
## Summary
- start a Go-based rewrite under `golang/`
- add minimal Gin server and configuration loader
- implement placeholders for routing, guardrails, metrics and observability
- include Dockerfile and sample config
- add basic provider and routing

## Testing
- ❌ `cargo test --quiet` (failed: `cargo` not found)
- ❌ `go test ./...` (failed to fetch modules)

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_b_68470bc4229c832c8911fcf9bdf37b28